### PR TITLE
Clearing promise contexts after completion

### DIFF
--- a/lib/CacheCluster.js
+++ b/lib/CacheCluster.js
@@ -200,6 +200,7 @@ CacheCluster.prototype.mget = function (keys) {
   return Q.all(promises)
     .setContext({keys: keys, keyIndexes: keyIndexes, serverArr: serverArr})
     .then(processMgetResults)
+    .clearContext()
 }
 
 CacheCluster.prototype.get = function (key) {

--- a/lib/ConnectionPool.js
+++ b/lib/ConnectionPool.js
@@ -106,6 +106,7 @@ ConnectionPool.prototype.mget = function (keys) {
   var promise = this._acquireClient()
     .setContext({keys: keys})
     .then(callMget)
+    .clearContext()
 
   return this._prepareReleaseClient(promise)
 }
@@ -126,6 +127,7 @@ ConnectionPool.prototype.get = function (key) {
   var promise = this._acquireClient()
     .setContext({key: key})
     .then(callGet)
+    .clearContext()
 
   return this._prepareReleaseClient(promise)
 }
@@ -146,6 +148,7 @@ ConnectionPool.prototype.set = function (key, val, maxAgeMs) {
   var promise = this._acquireClient()
     .setContext({key: key, val: val, maxAgeMs: maxAgeMs})
     .then(callSet)
+    .clearContext()
 
   return this._prepareReleaseClient(promise)
 }
@@ -166,6 +169,7 @@ ConnectionPool.prototype.del = function (key) {
   var promise = this._acquireClient()
     .setContext({key: key})
     .then(callDel)
+    .clearContext()
 
   return this._prepareReleaseClient(promise)
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   , "dependencies": {
       "node-memcache-parser-obvfork": "0.1.1",
       "generic-pool": "2.0.3",
-      "kew": "0.1.3",
+      "kew": "0.1.5",
       "redis": "0.8.2"
   }
   , "devDependencies": {


### PR DESCRIPTION
Hello eford, 

Please review the following commits I made in branch 'azulus-callbacks'.

367d49378a58208a81653571ce9e85c080eef44b (2013-04-16 15:43:12 -0700)
Clearing promise contexts

100ca8916bf4c875399c80e674645073d9bf5745 (2013-04-15 15:43:47 -0700)
More doc blocks

6d331555baa2ec53308671273c3f7f005d3c8a57 (2013-04-15 15:42:20 -0700)
+doc blocks

ca8e88efdf4bf7125994eea55757a2d64e672f5d (2013-04-15 15:35:59 -0700)
Removing callbacks in favor of contexts

51bb32161a05ae81ce181dd985d930d94a0c3f7b (2013-04-15 15:21:03 -0700)
Flipped ConnectionPool to use promise contexts

R=eford
