### PR TITLE
Quieting down shepherd logging if no cache instance found

### DIFF
--- a/lib/RedundantCacheGroup.js
+++ b/lib/RedundantCacheGroup.js
@@ -3,8 +3,6 @@ var Q = require('kew')
 
 var CacheInstance = require('./CacheInstance')
 
-var NO_INSTANCE_FOUND_RESPONSE = Q.reject(new Error('No cache instance is currently available'))
-
 function RedundantCacheGroup() {
   CacheInstance.call(this)
 
@@ -74,14 +72,14 @@ RedundantCacheGroup.prototype.destroy = function () {
 
 RedundantCacheGroup.prototype.mget = function (keys) {
   var instance = this._getAvailableInstance()
-  if (!instance) return NO_INSTANCE_FOUND_RESPONSE
+  if (!instance) return Q.resolve([])
 
   return instance.mget(keys)
 }
 
 RedundantCacheGroup.prototype.get = function (key) {
   var instance = this._getAvailableInstance()
-  if (!instance) return NO_INSTANCE_FOUND_RESPONSE
+  if (!instance) return Q.resolve(undefined)
 
   return instance.get(key)
 }


### PR DESCRIPTION
Hello @eford1, @skuwamoto, 

Please review the following commits I made in branch 'azulus-logging'.

adca5af828d0bdee38062f5811edf3fc25823b70 (2013-05-28 10:49:13 -0700)
Quieting down unnecessary logging

R=@eford1
R=@skuwamoto
