### PR TITLE
Add MSET support to the redundant cache group

### DIFF
--- a/lib/RedisConnection.js
+++ b/lib/RedisConnection.js
@@ -31,13 +31,14 @@ RedisConnection.prototype.set = function (key, val, maxAgeMs) {
     .fail(warnOnError)
 }
 
-RedisConnection.prototype.mset = function (objects, maxAgeMs) {
+RedisConnection.prototype.mset = function (items, maxAgeMs) {
   var deferred = Q.defer()
   var msetCommand = ["MSET"]
   var commands = [msetCommand]
-  for (var key in objects) {
+  for (var i = 0, l = items.length; i < l; i++) {
+    var key = items[i].key
     // Append key value arguments to the set command.
-    msetCommand.push(key, objects[key])
+    msetCommand.push(key, items[i].value)
     // Append an expire command.
     commands.push(["PEXPIRE", key, maxAgeMs])
   }

--- a/lib/RedundantCacheGroup.js
+++ b/lib/RedundantCacheGroup.js
@@ -84,10 +84,16 @@ RedundantCacheGroup.prototype.get = function (key) {
   return instance.get(key)
 }
 
+RedundantCacheGroup.prototype.mset = function (items, maxAgeMs) {
+  var instance = this._getAvailableInstance()
+  if (!instance) return Q.resolve(undefined)
+
+  return instance.mset(items, maxAgeMs)
+}
+
 RedundantCacheGroup.prototype.set = function (key, val, maxAgeMs) {
   var instances = this._getAllInstances()
   var promises = []
-
   for (var i = 0; i < instances.length; i++) {
     promises.push(instances[i].set(key, val, maxAgeMs))
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zcache"
   , "description": "AWS zone-aware caching"
-  , "version": "0.2.0"
+  , "version": "0.2.1"
   , "homepage": "https://github.com/azulus/zcache"
   , "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"

--- a/test/test_RedisConnection.js
+++ b/test/test_RedisConnection.js
@@ -46,7 +46,13 @@ exports.testRedisConnection = function (test) {
         test.equal(vals[0], undefined)
       })
       .then(function () {
-        return cacheInstance.mset({a: '456', b: '789'}, 300000)
+        return cacheInstance.mset([{
+          key: 'a',
+          value: '456'
+        }, {
+          key: 'b',
+          value: '789'
+        }], 300000)
       })
       .then(function () {
         return cacheInstance.mget(['a', 'b'])


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'jamie-mset'.

1fd0cbf4391ca3971bcc046d39cfeb59bcc50d2e (2013-07-15 09:56:22 -0700)
Separate MSET args to keys and values

R=@x-ma
