### PR TITLE
Remove PSET commands to restore Redis 2.4.8 compatibility

### DIFF
--- a/lib/RedisConnection.js
+++ b/lib/RedisConnection.js
@@ -25,7 +25,7 @@ RedisConnection.prototype.isAvailable = function () {
 
 RedisConnection.prototype.set = function (key, val, maxAgeMs) {
   var deferred = Q.defer()
-  this._client.psetex(key, maxAgeMs, val, deferred.makeNodeResolver())
+  this._client.setex(key, Math.floor(maxAgeMs / 1000), val, deferred.makeNodeResolver())
 
   return deferred.promise
     .fail(warnOnError)
@@ -40,7 +40,7 @@ RedisConnection.prototype.mset = function (items, maxAgeMs) {
     // Append key value arguments to the set command.
     msetCommand.push(key, items[i].value)
     // Append an expire command.
-    commands.push(["PEXPIRE", key, maxAgeMs])
+    commands.push(["EXPIRE", key, Math.floor(maxAgeMs / 1000)])
   }
   this._client.multi(commands).exec(deferred.makeNodeResolver())
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zcache"
   , "description": "AWS zone-aware caching"
-  , "version": "0.2.1"
+  , "version": "0.2.2"
   , "homepage": "https://github.com/azulus/zcache"
   , "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'jamie-redis-compat'.

3ee0c64f448c160467c2522ee316cc42a73ba74d (2013-07-22 17:28:21 -0700)
Remove PSET commands to restore Redis 2.4.8 compatibility

R=@x-ma
