### PR TITLE
Make RedisConnection.prototype.mget call underlying client with most performant argument pattern

### DIFF
--- a/lib/RedisConnection.js
+++ b/lib/RedisConnection.js
@@ -65,8 +65,7 @@ RedisConnection.prototype.mget = function (keys) {
   if (!keys || !keys.length) return Q.resolve([])
 
   var deferred = Q.defer()
-  var args = keys.concat(deferred.makeNodeResolver())
-  this._client.mget.apply(this._client, args)
+  this._client.mget(keys, deferred.makeNodeResolver())
   return deferred.promise
 }
 


### PR DESCRIPTION
Hello @majelbstoat, @x-ma, 

Please review the following commits I made in branch 'don-mget-order'.

ea1202945838b9f00f6c94ab4d22c8f6c0d83d12 (2013-07-30 18:53:12 -0700)
Make RedisConnection.prototype.mget call underlying client with most performant argument pattern

R=@majelbstoat
R=@x-ma
