### PR TITLE
change overrideTTL to overrideMaxAgeMs

### DIFF
--- a/lib/InMemoryCache.js
+++ b/lib/InMemoryCache.js
@@ -16,11 +16,11 @@ function InMemoryCache() {
 
   // if this is set to a number > 0, each item will live this many ms instead
   // of maxAgesMs passed in to set/mset
-  this._ttlMaxAgeOverride = false
+  this._maxAgeOverride = false
 
   // The reaper interval
-  this._reaperInterval = this._createReaper()
-  this._isAvailable = true
+  this._reaperInterval = null
+  this._isAvailable = false
 }
 util.inherits(InMemoryCache, CacheInstance)
 
@@ -54,8 +54,8 @@ InMemoryCache.prototype.setReaperInterval = function (everyMs) {
 }
 
 // set a custom ttl for every object added to the cache from here on out
-InMemoryCache.prototype.overrideTTL = function (maxAgeMs) {
-  this._ttlMaxAgeOverride = maxAgeMs
+InMemoryCache.prototype.overrideMaxAgeMs = function (maxAgeMs) {
+  this._maxAgeOverride = maxAgeMs
 }
 
 InMemoryCache.prototype.isAvailable = function () {
@@ -96,7 +96,7 @@ InMemoryCache.prototype.mget = function (keys) {
 }
 
 InMemoryCache.prototype.set = function (key, val, maxAgeMs) {
-  this._expireAt[key] = Date.now() + (this._ttlMaxAgeOverride || maxAgeMs )
+  this._expireAt[key] = Date.now() + (this._maxAgeOverride || maxAgeMs )
   return this._data[key] = val
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zcache"
   , "description": "AWS zone-aware caching"
-  , "version": "0.2.3"
+  , "version": "0.2.4"
   , "homepage": "https://github.com/azulus/zcache"
   , "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)"

--- a/test/test_InMemoryCache.js
+++ b/test/test_InMemoryCache.js
@@ -3,6 +3,7 @@ var Q = require('kew')
 
 exports.setUp = function (callback) {
   this.cI = new zcache.InMemoryCache()
+  this.cI.connect()
   callback()
 }
 
@@ -22,8 +23,8 @@ exports.testCacheSet = function (test) {
   test.done()
 }
 
-exports.testCacheTTLOverride = function (test) {
-  this.cI.overrideTTL(1) // super short
+exports.testCacheOverrideMaxAgeMs = function (test) {
+  this.cI.overrideMaxAgeMs(1) // super short
   this.cI.set('foo', 'bar')
 
   setTimeout(function () {

--- a/test/test_RedundantCacheGroup.js
+++ b/test/test_RedundantCacheGroup.js
@@ -4,7 +4,9 @@ var Q = require('kew')
 module.exports = {
   setUp: function (callback) {
     this.memoryInstance1 = new zcache.InMemoryCache()
+    this.memoryInstance1.connect()
     this.memoryInstance2 = new zcache.InMemoryCache()
+    this.memoryInstance2.connect()
 
     this.cacheInstance = new zcache.RedundantCacheGroup()
     this.cacheInstance.add(this.memoryInstance1, 2)


### PR DESCRIPTION
Hello @x-ma,

There's also a change where you still have to call `.connect()` on the
in-memory cache to stay "api-compliant"

f20fec5f7eaf07138d9ddfe20160701982d01ac8 (2013-08-02 13:06:09 -0700)
change overrideTTL to overrideMaxAgeMs

R=@x-ma
