### PR TITLE
Add an API to get the number of keys in the InMemoryCache

### DIFF
--- a/lib/InMemoryCache.js
+++ b/lib/InMemoryCache.js
@@ -39,6 +39,19 @@ function InMemoryCache() {
 util.inherits(InMemoryCache, CacheInstance)
 
 /**
+ * Get the number of keys currently in the cache.
+ *
+ * Note: this function returns the number of keys that are in the cache
+ *       and taking memory, but some of them might have expired already
+ *       and the reaper will remove them when it runs.
+ *
+ * @return {number} The number of keys
+ */
+InMemoryCache.prototype.getKeyCount = function () {
+  return Object.keys(this._data).length
+}
+
+/**
  * Set how frequently the reaper runs.
  *
  * @param {number} everyMs The interval of two consecutive runs of the reaper, in milliseconds.

--- a/test/test_InMemoryCache.js
+++ b/test/test_InMemoryCache.js
@@ -20,8 +20,10 @@ exports.testInMemoryCache = function (test) {
 }
 
 exports.testCacheSet = function (test) {
+  test.equal(0, this.cI.getKeyCount(), 'There is no key in cache')
   this.cI.set('foo', 'bar', 10000)
   test.equal(this.cI._data['foo'], 'bar', 'bar should be returned')
+  test.equal(1, this.cI.getKeyCount(), 'There is 1 key in cache')
   test.done()
 }
 
@@ -108,6 +110,7 @@ exports.testCacheMset = function (test) {
   test.equal(this.cI._data['a'], 1, 'a should be 1')
   test.equal(this.cI._data['b'], 2, 'b should be 2')
   test.equal(this.cI._data['c'], 3, 'c should be 3')
+  test.equal(3, this.cI.getKeyCount(), 'There are 3 keys in cache')
   test.done()
 }
 


### PR DESCRIPTION
Hello @ArtemTitoulenko, 

Please review the following commits I made in branch 'xiao-add-key-count'.

509fe14c53a82b84eb58e0228fd2510983300d85 (2013-08-07 13:18:21 -0700)
Add an API to get the number of keys in the InMemoryCache

R=@ArtemTitoulenko
