### PR TITLE
undefined for expired items, undefined in mget results, error on invalid maxAgeMs

### DIFF
--- a/lib/InMemoryCache.js
+++ b/lib/InMemoryCache.js
@@ -114,6 +114,8 @@ InMemoryCache.prototype.mget = function (keys) {
     if (this._expireAt[keys[i]] > Date.now()) {
       ret[i] = this._data[keys[i]]
       this._hitCount += 1
+    } else {
+      ret[i] = undefined
     }
   }
   return Q.resolve(ret)
@@ -121,6 +123,8 @@ InMemoryCache.prototype.mget = function (keys) {
 
 /** @inheritDoc */
 InMemoryCache.prototype.set = function (key, val, maxAgeMs) {
+  if ((maxAgeMs === undefined || maxAgeMs <= 0) && !this._maxAgeOverride) throw new Error('maxAge must either be positive or overriden with a positive overrideMaxAgeMs')
+
   this._expireAt[key] = Date.now() + (this._maxAgeOverride || maxAgeMs )
   return this._data[key] = val
 }

--- a/lib/RedundantCacheGroup.js
+++ b/lib/RedundantCacheGroup.js
@@ -95,7 +95,7 @@ RedundantCacheGroup.prototype.mget = function (keys, start) {
 
           promises.push(self.mget(rollUp, nextInstanceIndex)
             .then(function (itemIndex, data) {
-              if (data == undefined) return undefined
+              if (data === undefined) return undefined
               for (var k = 0; k < data.length; k++) res[itemIndex + k] = data[k]
             }.bind(null, startOfHole)))
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcache",
   "description": "AWS zone-aware multi-layer cache",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "homepage": "https://github.com/Obvious/zcache",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)",

--- a/test/test_RedundantCacheGroup.js
+++ b/test/test_RedundantCacheGroup.js
@@ -65,6 +65,15 @@ module.exports = {
       })
   },
 
+  testCacheMgetUndefinedMget: function (test) {
+    this.cacheInstance.mget(['foo', 'bar'])
+      .then(function (results) {
+        test.deepEqual(results[0], undefined, 'foo should be undefined')
+        test.deepEqual(results[1], undefined, 'bar should be undefined')
+        test.done()
+      })
+  },
+
   testCacheMgetMultipleSingleHolesStagger: function (test) {
     this.cacheInstance.set('one', 'one', 10000)
 
@@ -176,7 +185,7 @@ module.exports = {
   },
 
   testCacheMsetStagger: function (test) {
-    this.cacheInstance.mset([{key: 'foo', value: 'bar'}, {key: 'fah', value: 'bah'}])
+    this.cacheInstance.mset([{key: 'foo', value: 'bar'}, {key: 'fah', value: 'bah'}], 1000)
 
     test.equal(this.memoryInstance1._data['foo'], 'bar', 'bar should be in memoryInstance1')
     test.equal(this.memoryInstance2._data['foo'], 'bar', 'bar should be in memoryInstance2')


### PR DESCRIPTION
Hello @x-ma,

Please review the following commits I made in branch 'artem-mget-undefined'.

67509410f0cc956801d6f8b4ca5c5011831f3326 (2013-08-12 20:04:39 -0700)
undefined for expired items, undefined in mget results, error on invalid maxAgeMs
if an item is expired or doesn't exist, get/mget returns undefined

if an array of `n` items are passed into `mget`, an array of `n` results
will be returned with `undefined` as the placeholder for items that are either
not in the cache or have expired.

if the maxAge of an item was not overriden in a InMemoryCache, or it
was not positive, `set` and `mset` will throw an error saying so.

R=@x-ma
