### PR TITLE
Let CacheCluster keep track of partial failure count

### DIFF
--- a/lib/CacheCluster.js
+++ b/lib/CacheCluster.js
@@ -10,6 +10,7 @@ var HashRing = require('hashring')
 var CacheInstance = require('./CacheInstance')
 var PartialResultError = require('./PartialResultError')
 var TimeoutError = require('./TimeoutError')
+var metrics = require('metrics')
 
 /**
  * @param {Object=} options Additional options for this connection.
@@ -26,6 +27,7 @@ function CacheCluster(options) {
   this._capacityWarmUpMs = {}
   this._currentCapacities = {}
   this._targetCapacities = {}
+  this._partialFailureCount = {}
   this._hashRing = null
 }
 util.inherits(CacheCluster, CacheInstance)
@@ -130,6 +132,7 @@ CacheCluster.prototype.mget = function (keys) {
       if (Object.keys(errors).length === 0) {
         return keys.map(function (key) {return values[key]})
       } else {
+        self.getPartialFailureCount('mget').inc()
         throw new PartialResultError(values, errors)
       }
     })
@@ -175,6 +178,7 @@ CacheCluster.prototype.mset = function (items, maxAgeMs) {
   var promise = Q.allSettled(promises)
     .then(function() {
       if (Object.keys(errors).length > 0) {
+        self.getPartialFailureCount('mset').inc()
         throw new PartialResultError({}, errors)
       }
     })
@@ -186,6 +190,17 @@ CacheCluster.prototype.mset = function (items, maxAgeMs) {
 CacheCluster.prototype.del = function (key) {
   var cacheInstance = this._servers[this._hashRing.get(key)]
   return cacheInstance.del(key)
+}
+
+/**
+ * Get the partial failure count of a certain operation.
+ *
+ * @param {string} op The name of the operation, e.g., mget or mset.
+ * @return {metrics.Counter}
+ */
+CacheCluster.prototype.getPartialFailureCount = function (op) {
+  if (!this._partialFailureCount[op]) this._partialFailureCount[op] = new metrics.Counter()
+  return this._partialFailureCount[op]
 }
 
 /**

--- a/test/test_CacheCluster.js
+++ b/test/test_CacheCluster.js
@@ -104,6 +104,7 @@ builder.add(function testPartialMgetFailure(test) {
     })
     .fail(function (err) {
       test.ok(err instanceof PartialResultError)
+      test.equal(1, cluster.getPartialFailureCount('mget').count)
       var data = err.getData()
       var error = err.getError()
       for (var i = 0; i < 100; i++) {
@@ -142,6 +143,7 @@ builder.add(function testPartialMsetFailure(test) {
     })
     .fail(function (err) {
       test.ok(err instanceof PartialResultError)
+      test.equal(1, cluster.getPartialFailureCount('mset').count)
       var data = err.getData()
       var error = err.getError()
 


### PR DESCRIPTION
Hello @nicks, @dpup, 

Please review the following commits I made in branch 'xiao-count-partial-failure'.

f10072f91566c4a21f62a5c86770a7eb0543abe0 (2014-01-27 15:47:10 -0800)
Let CacheCluster keep track of partial failure count

R=@nicks
R=@dpup
