### PR TITLE
Provide a public API to get cache instances within a cluster

### DIFF
--- a/lib/CacheCluster.js
+++ b/lib/CacheCluster.js
@@ -52,6 +52,18 @@ CacheCluster.prototype.addNode = function (uri, instance, capacity, warmUpMs) {
 }
 
 /**
+ * Retrieve all the cache server nodes.
+ *
+ * @return {Object.<string, CacheInstance>} A map from URIs to objects of existing
+ *    cache nodes
+ */
+CacheCluster.prototype.getNodes = function () {
+  var servers = {}
+  for (var uri in this._servers) servers[uri] = this._servers[uri]
+  return servers
+}
+
+/**
  * Update the capacity of an existng node.
  *
  * @param {string} uri The URI of the node


### PR DESCRIPTION
Hello @nicks, @dpup, 

Please review the following commits I made in branch 'xiao-add-api-to-servers'.

7aa84cb52cfb10715e4a1582ff3caa0f5c316830 (2014-01-27 15:55:25 -0800)
Provide a public API to get cache instances within a cluster

R=@nicks
R=@dpup
