### PR TITLE
Add a new API, getUri(), to all cache instances.

### DIFF
--- a/lib/CacheCluster.js
+++ b/lib/CacheCluster.js
@@ -140,6 +140,11 @@ CacheCluster.prototype.mget = function (keys) {
 }
 
 /** @override */
+CacheCluster.prototype.getUrisByKey = function (key) {
+  return [this._hashRing.get(key)]
+}
+
+/** @override */
 CacheCluster.prototype.get = function (key) {
   var cacheInstance = this._servers[this._hashRing.get(key)]
   return this._wrapPromiseWithProfiling(cacheInstance.get(key), 'get')

--- a/lib/CacheInstance.js
+++ b/lib/CacheInstance.js
@@ -118,6 +118,16 @@ CacheInstance.prototype.del = function (key) {
 }
 
 /**
+ * Get the uri of the cache server(s) that is in charge of the given key.
+ *
+ * @param {string} key
+ * @return {Array.<string>}
+ */
+CacheInstance.prototype.getUrisByKey = function (key) {
+  return ['UnknownUri']
+}
+
+/**
  * Get the number of cache accesses.
  *
  * @return {number}

--- a/lib/FakeCache.js
+++ b/lib/FakeCache.js
@@ -103,6 +103,11 @@ FakeCache.prototype.mset = function (items) {
     })
 }
 
+/** @override */
+FakeCache.prototype.getUrisByKey = function (key) {
+  return ['FakeCache']
+}
+
 /**
  * A sync version of the mget().
  */

--- a/lib/InMemoryCache.js
+++ b/lib/InMemoryCache.js
@@ -144,6 +144,11 @@ InMemoryCache.prototype.del = function (key) {
 }
 
 /** @override */
+InMemoryCache.prototype.getUrisByKey = function (key) {
+  return ['InMemoryCache']
+}
+
+/** @override */
 CacheInstance.prototype.getPendingRequestsCount = function () {
   var requestCounts = {}
   requestCounts['count'] = 0

--- a/lib/MultiWriteCacheGroup.js
+++ b/lib/MultiWriteCacheGroup.js
@@ -110,6 +110,19 @@ MultiWriteCacheGroup.prototype.resetTimeoutCount = function (op) {
   return this._instance.resetTimeoutCount(op)
 }
 
+/** @override */
+MultiWriteCacheGroup.prototype.getUrisByKey = function (key) {
+  var uris = this._instance.getUrisByKey(key)
+
+  this._writeOnlyInstances.forEach(function (instance) {
+    instance.getUrisByKey(key).forEach(function (uri) {
+      if (uris.indexOf(uri) < 0) uris.push(uri)
+    })
+  })
+
+  return uris
+}
+
 /**
  * A helper function that does write operations, set, mset and del, to all
  * the instances in a group.

--- a/lib/MultiplexingCache.js
+++ b/lib/MultiplexingCache.js
@@ -144,12 +144,19 @@ MultiplexingCache.prototype.getPrettyStatsString = function (op) {
 
 
 /** @override */
+MultiplexingCache.prototype.getUrisByKey = function (key) {
+  return this._delegate.getUrisByKey(key)
+}
+
+
+/** @override */
 MultiplexingCache.prototype.mset = function (items, maxAgeMs) {
   this._invalidateKeys(items)
   return this._delegate.mset(items, maxAgeMs)
 }
 
 
+/** @override */
 MultiplexingCache.prototype.set = function (key, val, maxAgeMs) {
   this._invalidateKeys([key])
   return this._delegate.set(key, val, maxAgeMs)
@@ -161,7 +168,6 @@ MultiplexingCache.prototype.del = function (key) {
   this._invalidateKeys([key])
   return this._delegate.del(key)
 }
-
 
 /** @override */
 MultiplexingCache.prototype.get = function (key) {
@@ -219,7 +225,6 @@ MultiplexingCache.prototype.mget = function (keys) {
     return results
   })
 }
-
 
 /**
  * Deletes the promise for a set of keys or objects.

--- a/lib/RedisConnection.js
+++ b/lib/RedisConnection.js
@@ -23,6 +23,7 @@ function RedisConnection(host, port, options) {
   this._client = null
   this._host = host || null
   this._port = port || null
+  this._uri = this._host + ':' + this._port
   this._bound_onConnect = this._onConnect.bind(this)
   this._bound_onError = this._onError.bind(this)
   this._bound_onEnd = this._onEnd.bind(this)
@@ -156,18 +157,15 @@ RedisConnection.prototype.connect = function () {
   this._client.on('end', this._bound_onEnd)
 }
 
-/**
- * Gets the uri of the server
- * @return {string}
- */
-RedisConnection.prototype.getUri = function () {
-  return this._host + ':' + this._port
+/** @override */
+RedisConnection.prototype.getUrisByKey = function (key) {
+  return [this._uri]
 }
 
 /** @override */
 RedisConnection.prototype.getPendingRequestsCount = function () {
   var requestCounts = {
-    'uri': this.getUri(),
+    'uri': this._uri,
     'count': this._client.command_queue.length
   }
   return [requestCounts]

--- a/lib/RedundantCacheGroup.js
+++ b/lib/RedundantCacheGroup.js
@@ -158,6 +158,19 @@ RedundantCacheGroup.prototype.del = function (key) {
 }
 
 /** @override */
+RedundantCacheGroup.prototype.getUrisByKey = function (key) {
+  var uris = []
+
+  this._getAllInstances().forEach(function (instance) {
+    instance.getUrisByKey(key).forEach(function (uri) {
+      if (uris.indexOf(uri) < 0) uris.push(uri)
+    })
+  })
+
+  return uris
+}
+
+/** @override */
 RedundantCacheGroup.prototype.getPendingRequestsCount = function () {
   return cacheUtils.mergePendingRequestCounts(cacheInstnaces.map(function (obj) { return obj.instance }))
 }

--- a/test/test_CacheCluster.js
+++ b/test/test_CacheCluster.js
@@ -230,6 +230,18 @@ builder.add(function testDel(test) {
     })
 })
 
+builder.add(function testGetUri(test) {
+  var cluster = new zcache.CacheCluster()
+  cluster.addNode('FakeCache1', new zcache.FakeCache(logger), 1, 0)
+  cluster.addNode('FakeCache2', new zcache.FakeCache(logger), 1, 0)
+  cluster.addNode('FakeCache3', new zcache.FakeCache(logger), 1, 0)
+  cluster.connect()
+
+  test.equal('FakeCache2', cluster.getUrisByKey('foo'), 'Key "foo" should be on cache 2')
+  test.equal('FakeCache1', cluster.getUrisByKey('bar'), 'Key "foo" should be on cache 1')
+  test.done()
+})
+
 builder.add(function testCornerCaseWithOnlyOneNode(test) {
   var cluster = new zcache.CacheCluster()
   var fakeCache = new zcache.FakeCache(logger)


### PR DESCRIPTION
Hello @nicks, @sboora, 

Please review the following commits I made in branch 'xiao-geturi'.

205b3f7d7e183f643f3a7eec8c3aa634c29e8663 (2014-03-19 16:28:06 -0700)
Add a new API, getUri(), to all cache instances.
The reason to add this API is:

(1) We added this API to RedisInstance recently for tracking the behavior
    of each individual instance (c9224fc4c4b1b5b5b9b5f1d160486b9c5769b963).
(2) We will need to add this API to CacheCluster so we can query which
    cache server is in charge of a given key.

Given that we have added and will add this API to two types of instances,
and it could be useful in other scenarios as well, so it makes sense to
add to all of them.

R=@nicks
R=@sboora
