### PR TITLE
Avoid redundant writes across clusters that share same some cache servers

### DIFF
--- a/lib/FakeCache.js
+++ b/lib/FakeCache.js
@@ -15,8 +15,9 @@ var CACHE_LATENCY_MS = 5
  * @constructor
  * @extends CacheInstance
  * @param {Logger} logger A logger for logging debug information.
+ * @param {uri=} optUri Give an URI to this fake cache instance
  */
-function FakeCache(logger) {
+function FakeCache(logger, optUri) {
   CacheInstance.call(this)
 
   this.flush()
@@ -24,6 +25,7 @@ function FakeCache(logger) {
   this._failureCount = 0
   this._latencyMs = CACHE_LATENCY_MS
   this._nextFailure = null
+  this._uri = optUri || 'FakeCache'
 }
 util.inherits(FakeCache, CacheInstance)
 
@@ -95,6 +97,7 @@ FakeCache.prototype.mset = function (items) {
   return Q.delay(this._latencyMs)
     .then(function actualMset() {
       self._requestCounts.mset += 1
+      self._requestCounts.msetItemCount.push(items.length)
       for (var i = 0; i < items.length; i++) {
         var item = items[i]
         self._data[item.key] = item.value
@@ -105,7 +108,7 @@ FakeCache.prototype.mset = function (items) {
 
 /** @override */
 FakeCache.prototype.getUrisByKey = function (key) {
-  return ['FakeCache']
+  return [this._uri]
 }
 
 /**
@@ -198,10 +201,12 @@ FakeCache.prototype.setLatencyMs = function (latencyMs) {
 FakeCache.prototype.resetRequestCounts = function () {
   this._requestCounts = {
     mget: 0,
+    mset: 0,
     get: 0,
     set: 0,
     del: 0,
     mgetItemCount: [],
+    msetItemCount: [],
     hitCount: 0,
     missCount: 0,
   }

--- a/lib/MultiWriteCacheGroup.js
+++ b/lib/MultiWriteCacheGroup.js
@@ -87,7 +87,35 @@ MultiWriteCacheGroup.prototype.set = function (key, val, maxAgeMs) {
 
 /** @override */
 MultiWriteCacheGroup.prototype.mset = function (items, maxAgeMs) {
-  return this._applyWrites('mset', arguments)
+  var promises = []
+  var appliedUrisByKey = {}
+  var self = this
+
+  promises.push(this._instance.mset(items, maxAgeMs))
+  items.forEach(function (item) {
+    appliedUrisByKey[item.key] = self._instance.getUrisByKey(item.key)
+  })
+
+  for (var i = 0; i < this._writeOnlyInstances.length; i++) {
+    var itemsToWrite = []
+    items.forEach(function (item) {
+      var key = item.key
+      var uris = self._writeOnlyInstances[i].getUrisByKey(key)
+      for (var j = 0; j < uris.length; j++) {
+        if (appliedUrisByKey[key].indexOf(uris[j]) < 0) {
+          // As long as we missed one uri (which is a server), we should mset
+          // the entire instance.
+          itemsToWrite.push(item)
+          appliedUrisByKey[key] = appliedUrisByKey[key].concat(uris)
+          break
+        }
+      }
+    })
+    if (itemsToWrite.length > 0) {
+      promises.push(this._writeOnlyInstances[i].mset(itemsToWrite, maxAgeMs))
+    }
+  }
+  return Q.all(promises)
 }
 
 /** @override */
@@ -127,17 +155,31 @@ MultiWriteCacheGroup.prototype.getUrisByKey = function (key) {
  * A helper function that does write operations, set, mset and del, to all
  * the instances in a group.
  *
- * @param {string} op The name of the operation. Must be one of 'set', 'mset' and 'del'.
- * @param {Array.<*>} arguments The arguments that passed in to the original function.
+ * @param {string} op The name of the operation. Must be  'set' or 'del'.
+ * @param {Array.<*>} args The arguments that passed in to the original function.
  * @return {Promise} A promise that indicates if the write is applied to all instances.
  *     The promise will be rejected *as long as* one of the instace fails to apply the
  *     the writes.
  */
-MultiWriteCacheGroup.prototype._applyWrites = function (op, arguments) {
+MultiWriteCacheGroup.prototype._applyWrites = function (op, args) {
   var promises = []
-  promises.push(this._instance[op].apply(this._instance, arguments))
+  // the first argument is always the key for both 'set' and 'del'
+  var key = args[0]
+
+  promises.push(this._instance[op].apply(this._instance, args))
+  var appliedUris = this._instance.getUrisByKey(key)
+
   for (var i = 0; i < this._writeOnlyInstances.length; i++) {
-    promises.push(this._writeOnlyInstances[i][op].apply(this._writeOnlyInstances[i], arguments))
+    var writeOnlyUris = this._writeOnlyInstances[i].getUrisByKey(key)
+    for (var j = 0; j < writeOnlyUris.length; j++) {
+      if (appliedUris.indexOf(writeOnlyUris[j]) < 0) {
+        // As long as we missed one uri (which is a server), we should run the op
+        // to the entire instance.
+        promises.push(this._writeOnlyInstances[i][op].apply(this._writeOnlyInstances[i], args))
+        appliedUris = appliedUris.concat(writeOnlyUris)
+        break
+      }
+    }
   }
   return Q.all(promises)
 }

--- a/test/test_MultiWriteCacheGroup.js
+++ b/test/test_MultiWriteCacheGroup.js
@@ -16,9 +16,9 @@ var TimeoutError = require('../lib/TimeoutError')
 global.setInterval = function () {}
 
 builder.add(function testGetAndGet(test) {
-  var cache1 = new zcache.FakeCache(logger)
-  var cache2 = new zcache.FakeCache(logger)
-  var cache3 = new zcache.FakeCache(logger)
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cache3 = new zcache.FakeCache(logger, 'FakeCache3')
   var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
   cacheGroup.addWriteOnlyNode(cache2)
   cacheGroup.addWriteOnlyNode(cache3)
@@ -51,9 +51,9 @@ builder.add(function testGetAndGet(test) {
 })
 
 builder.add(function testMgetAndMget(test) {
-  var cache1 = new zcache.FakeCache(logger)
-  var cache2 = new zcache.FakeCache(logger)
-  var cache3 = new zcache.FakeCache(logger)
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cache3 = new zcache.FakeCache(logger, 'FakeCache3')
   var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
   cacheGroup.addWriteOnlyNode(cache2)
   cacheGroup.addWriteOnlyNode(cache3)
@@ -84,9 +84,9 @@ builder.add(function testMgetAndMget(test) {
 })
 
 builder.add(function testFailure(test) {
-  var cache1 = new zcache.FakeCache(logger)
-  var cache2 = new zcache.FakeCache(logger)
-  var cache3 = new zcache.FakeCache(logger)
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cache3 = new zcache.FakeCache(logger, 'FakeCache3')
   var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
   cacheGroup.addWriteOnlyNode(cache2)
   cacheGroup.addWriteOnlyNode(cache3)
@@ -101,9 +101,9 @@ builder.add(function testFailure(test) {
 })
 
 builder.add(function testGetUri(test) {
-  var fakeCache1 = new zcache.FakeCache(logger)
-  var fakeCache2 = new zcache.FakeCache(logger)
-  var fakeCache3 = new zcache.FakeCache(logger)
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var fakeCache3 = new zcache.FakeCache(logger, 'FakeCache3')
 
   var cluster1 = new zcache.CacheCluster()
   cluster1.addNode('FakeCache1', fakeCache1, 1, 0)
@@ -122,4 +122,96 @@ builder.add(function testGetUri(test) {
   test.equal('FakeCache1,FakeCache3', cacheGroup.getUrisByKey('bar').sort().join(','), '"bar" exists on FakeCache1 and FakeCache3')
 
   test.done()
+})
+
+builder.add(function testAvoidRedudantMset(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache1')
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(fakeCache1)
+  cacheGroup.addWriteOnlyNode(fakeCache2)
+
+  var items = [
+    {key: 'key1', value: 'value1'},
+    {key: 'key2', value: 'value2'}
+  ]
+
+  return cacheGroup.mset(items)
+    .then(function() {
+      test.equals('value1', fakeCache1.getSync('key1'), 'key1 should exist in the first fake cache')
+      test.equals('value2', fakeCache1.getSync('key2'), 'key2 should exist in the first fake cache')
+      test.deepEqual(undefined, fakeCache2.getSync('key1'), 'key1 should not be in the second fake cache')
+      test.deepEqual(undefined, fakeCache2.getSync('key2'), 'key2 should not be in the second fake cache')
+    })
+})
+
+builder.add(function testAvoidRedudantSet(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache1')
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(fakeCache1)
+  cacheGroup.addWriteOnlyNode(fakeCache2)
+
+  return cacheGroup.set('key1', 'value1')
+    .then(function() {
+      test.equals('value1', fakeCache1.getSync('key1'), 'key1 should exist in the first fake cache')
+      test.deepEqual(undefined, fakeCache2.getSync('key1'), 'key1 should not be in the second fake cache')
+    })
+})
+
+builder.add(function testAvoidRedudantDel(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache1')
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(fakeCache1)
+  cacheGroup.addWriteOnlyNode(fakeCache2)
+  fakeCache1.setSync('key1', 'value1')
+  fakeCache2.setSync('key1', 'value1')
+
+  return cacheGroup.del('key1')
+    .then(function() {
+      test.deepEqual(undefined, fakeCache1.getSync('key1'), 'key1 should have been deleted in the first fake cache')
+      test.equals('value1', fakeCache2.getSync('key1'), 'key1 should still be in the second fake cache')
+    })
+})
+
+builder.add(function testAvoidRedudantMsetInCluster(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var fakeCache3 = new zcache.FakeCache(logger, 'FakeCache3')
+  var fakeCache4 = new zcache.FakeCache(logger, 'FakeCache4')
+
+  var cluster1 = new zcache.CacheCluster()
+  cluster1.addNode('FakeCache1', fakeCache1, 1, 0)
+  cluster1.addNode('FakeCache2', fakeCache2, 1, 0)
+  cluster1.addNode('FakeCache3', fakeCache3, 1, 0)
+  cluster1.connect()
+
+  var cluster2 = new zcache.CacheCluster()
+  cluster2.addNode('FakeCache1', fakeCache1, 1, 0)
+  cluster2.addNode('FakeCache2', fakeCache2, 1, 0)
+  cluster2.addNode('FakeCache3', fakeCache3, 1, 0)
+  cluster2.addNode('FakeCache4', fakeCache4, 1, 0)
+  cluster2.connect()
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cluster1)
+  cacheGroup.addWriteOnlyNode(cluster2)
+
+  var items = []
+  for (var i = 0; i < 1000; i++) {
+    items.push({
+      key: 'key' + i,
+      value: 'value' + i
+    })
+  }
+
+  return cacheGroup.mset(items)
+    .then(function() {
+      var n1 = fakeCache1.getRequestCounts()['msetItemCount'][0]
+      var n2 = fakeCache2.getRequestCounts()['msetItemCount'][0]
+      var n3 = fakeCache3.getRequestCounts()['msetItemCount'][0]
+      var n4 = fakeCache4.getRequestCounts()['msetItemCount'][0]
+      test.equals(1000, n1 + n2 + n3, 'The servers in the first cluster should get exactly 1000 sets')
+      test.ok(200 < n4 && n4 < 300, 'The new server in the second cluster should get about 1/4 of the keys')
+    })
 })


### PR DESCRIPTION
Hello @nicks, @sboora, @giannic, 

Please review the following commits I made in branch 'xiao-avoid-redudant-double-write'.

4e64d03553ad7f9197ddfa1896d8350bc7f4a3fb (2014-03-19 21:39:30 -0700)
Avoid redundant writes across clusters that share same some cache servers

R=@nicks
R=@sboora
R=@giannic
