### PR TITLE
Read missed keys from secondary server

### DIFF
--- a/lib/MultiWriteCacheGroup.js
+++ b/lib/MultiWriteCacheGroup.js
@@ -23,6 +23,8 @@ function MultiWriteCacheGroup(instance) {
   this._isConnected = false
   this._instance = instance
   this._writeOnlyInstances = []
+  this._shouldReadFromSecondary = false
+  this._writeBackMaxAgeMs = -1
 }
 util.inherits(MultiWriteCacheGroup, CacheInstance)
 
@@ -33,6 +35,19 @@ util.inherits(MultiWriteCacheGroup, CacheInstance)
  */
 MultiWriteCacheGroup.prototype.addWriteOnlyNode = function (instance) {
   this._writeOnlyInstances.push(instance)
+}
+
+/**
+ * Enable to read from the secondary server if a key is missed in
+ * the primary server. It will also write back to the primary server
+ * if it hits the secondary server, using the "defaultMaxAgeMs".
+ *
+ * @param {number} writeBackMaxAgeMs The live time to use when write back to
+ *   to the primary server.
+ */
+MultiWriteCacheGroup.prototype.enableReadFromSecondary = function (writeBackMaxAgeMs) {
+  this._shouldReadFromSecondary = true
+  this._writeBackMaxAgeMs = writeBackMaxAgeMs
 }
 
 /** @override */
@@ -72,12 +87,64 @@ MultiWriteCacheGroup.prototype.destroy = function () {
 
 /** @override */
 MultiWriteCacheGroup.prototype.mget = function (keys) {
-  return this._instance.mget(keys)
+  var self = this
+
+  var resultPromise = this._instance.mget(keys)
+  if (!this._shouldReadFromSecondary) return resultPromise
+
+  return resultPromise
+    .then(function (values) {
+      // collect the keys that are missed from the primary server
+      var keysToRead = []
+      var indexOfKeysToRead = []
+      for (var i = 0; i < values.length; i++) {
+        if (values[i] === undefined && self._maybeOnSecondary(keys[i])) {
+          indexOfKeysToRead.push(i)
+          keysToRead.push(keys[i])
+        }
+      }
+      if (keysToRead.length === 0) return values
+
+      // try to get the missed keys from the secondary server
+      // TODO: will change to have only *one* secondary instance soon.
+      return self._writeOnlyInstances[0].mget(keysToRead)
+        .then(function (valuesRead) {
+          var itemsToCache = []
+          // Go through the original results from the primary server
+          // and fill holes (i.e., missed items).
+          for (var i = 0; i < keysToRead.length; i++) {
+            if (valuesRead[i] !== undefined) {
+              values[indexOfKeysToRead[i]] = valuesRead[i]
+              itemsToCache.push({
+                key: keysToRead[i],
+                value: valuesRead[i]
+              })
+            }
+          }
+          // Note: we don't wait for this mset promise.
+          if (itemsToCache.length > 0) self.mset(itemsToCache, self._writeBackMaxAgeMs, true)
+          return values
+        })
+    })
 }
 
 /** @override */
 MultiWriteCacheGroup.prototype.get = function (key) {
+  var self = this
   return this._instance.get(key)
+    .then(function (value) {
+      if (value === undefined && self._shouldReadFromSecondary && self._maybeOnSecondary(key)) {
+        // TODO: will change to have only *one* secondary instance soon.
+        return self._writeOnlyInstances[0].get(key)
+          .then(function (value) {
+            // Note: we don't wait for this set promise
+            if (value !== undefined) self._instance.set(key, value, self._writeBackMaxAgeMs, true)
+            return value
+          })
+      } else {
+        return value
+      }
+    })
 }
 
 /** @override */
@@ -187,6 +254,25 @@ MultiWriteCacheGroup.prototype._applyWrites = function (op, args) {
 /** @override */
 MultiWriteCacheGroup.prototype.getPendingRequestsCount = function () {
   return cacheUtils.mergePendingRequestCounts(this._writeOnlyInstances.concat(this._instance))
+}
+
+/**
+ * A helper function to tell if a key may be on one of the servers in
+ * the secondary instance. It compares the all the URIs of the key in
+ * the secondary instance, and as long as one of them is not in the
+ * primary, it will return true to indicate the key may be located on
+ * the secondary instance.
+ *
+ * @param {string} key The key to check
+ * @return {boolean}
+ */
+MultiWriteCacheGroup.prototype._maybeOnSecondary = function (key) {
+  var urisPrimary = this._instance.getUrisByKey(key)
+  var urisSecondary = this._writeOnlyInstances[0].getUrisByKey(key)
+  for (var i = 0; i < urisSecondary.length; i++) {
+    if (urisPrimary.indexOf(urisSecondary[i]) < 0) return true
+  }
+  return false
 }
 
 module.exports = MultiWriteCacheGroup

--- a/test/test_MultiWriteCacheGroup.js
+++ b/test/test_MultiWriteCacheGroup.js
@@ -215,3 +215,239 @@ builder.add(function testAvoidRedudantMsetInCluster(test) {
       test.ok(200 < n4 && n4 < 300, 'The new server in the second cluster should get about 1/4 of the keys')
     })
 })
+
+builder.add(function testGetFromReadSecondary(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  cache2.setSync('key', 'value')
+  return cacheGroup.get('key')
+    .then(function (data) {
+      test.equal('value', data, 'The get() should return the right value from the secondary instance')
+      test.equals(1, cache2.getRequestCounts()['get'], 'The secondary cache should get one get()')
+
+      // the following is a fragile test... any better ideas?
+      return Q.delay(20)
+    })
+    .then(function () {
+      test.equals('value', cache1.getSync('key'), 'key should be been written back to cache1')
+    })
+})
+
+builder.add(function testGetFromReadSecondaryAndMiss(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  return cacheGroup.get('key')
+    .then(function (data) {
+      test.equal(undefined, data, 'The get() should return undefined since it is missing in both servers')
+      test.equals(1, cache2.getRequestCounts()['get'], 'The secondary cache should get one get()')
+
+      // the following is a fragile test... any better ideas?
+      return Q.delay(20)
+    })
+    .then(function () {
+      test.equals(undefined, cache1.getSync('key'), 'key should be still a miss')
+    })
+})
+
+
+builder.add(function testGetFromReadSecondaryAndHit(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  cache2.setSync('key', 'value')
+  return cacheGroup.get('key')
+    .then(function (data) {
+      test.equal('value', data, 'The get() should return the right value from the secondary instance')
+      test.equals(1, cache2.getRequestCounts()['get'], 'The secondary cache should get one get()')
+
+      // the following is a fragile test... any better ideas?
+      return Q.delay(20)
+    })
+    .then(function () {
+      test.equals('value', cache1.getSync('key'), 'key should be been written back to cache1')
+    })
+})
+
+
+// Test mget() from both primary and seconday. All the keys already
+// exist in primary, i.e., we should *not* query secondary at all.
+builder.add(function testMgetFromReadSecondaryAllInPrimary(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  cache1.setSync('key1', 'value1')
+  cache1.setSync('key2', 'value2')
+  cache1.setSync('key3', 'value3')
+  return cacheGroup.mget(['key1', 'key2', 'key3'])
+    .then(function (data) {
+      test.deepEqual(['value1', 'value2', 'value3'], data, 'The mget() should return the right value from the primary instance')
+      test.equals(0, cache2.getRequestCounts()['mget'], 'The secondary cache should never been called for mget()')
+    })
+})
+
+
+// Test mget() from both primary and seconday. All the keys only
+// exist in secondary.
+builder.add(function testMgetFromReadSecondaryAllInSecondary(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  cache2.setSync('key1', 'value1')
+  cache2.setSync('key2', 'value2')
+  cache2.setSync('key3', 'value3')
+  return cacheGroup.mget(['key1', 'key2', 'key3'])
+    .then(function (data) {
+      test.deepEqual(['value1', 'value2', 'value3'], data, 'The mget() should return the right value from the secondary instance')
+      test.equals(1, cache2.getRequestCounts()['mget'], 'The secondary cache should get one mget()')
+      test.equals(3, cache2.getRequestCounts()['mgetItemCount'][0], 'The secondary cache should be asked for three keys')
+
+      // the following is a fragile test... any better ideas?
+      return Q.delay(20)
+    })
+    .then(function () {
+      test.equals(1, cache1.getRequestCounts()['mset'], 'All three keys should be mset() back to primary')
+      test.equals(3, cache1.getRequestCounts()['msetItemCount'][0], 'All three keys should be mset() back to primary')
+      test.equals('value1', cache1.getSync('key1'), 'key1 should exist in primary now')
+      test.equals('value2', cache1.getSync('key2'), 'key2 should exist in primary now')
+      test.equals('value3', cache1.getSync('key3'), 'key3 should exist in primary now')
+    })
+})
+
+// Test mget() from both primary and seconday. This test case gets
+// 5 keys, two of them exist in primary, two of them exist only on
+// secondary, and the other one is missing in both.
+builder.add(function testMgetFromReadSecondaryMixed(test) {
+  var cache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var cache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cache1)
+  cacheGroup.addWriteOnlyNode(cache2)
+  cacheGroup.enableReadFromSecondary(10)
+  cacheGroup.connect()
+
+  cache1.setSync('key1', 'value1')
+  cache2.setSync('key2', 'value2')
+  cache1.setSync('key3', 'value3')
+  cache2.setSync('key4', 'value4')
+  // 'key5' is missing both
+
+  return cacheGroup.mget(['key1', 'key2', 'key3', 'key4', 'key5'])
+    .then(function (data) {
+      test.deepEqual(['value1', 'value2', 'value3', 'value4', undefined], data, 'The mget() should return the right value from the secondary instance')
+      test.equals(1, cache2.getRequestCounts()['mget'], 'The secondary cache should get one mget()')
+      test.equals(3, cache2.getRequestCounts()['mgetItemCount'][0], 'The secondary cache should be asked for three keys')
+
+      // the following is a fragile test... any better ideas?
+      return Q.delay(20)
+    })
+    .then(function () {
+      // Notice, although 3 keys are missing, we only back fill two of them,
+      // because 'key5' is also missing in secondary.
+      test.equals(1, cache1.getRequestCounts()['mset'], 'Two of the missed keys should be mset() back to primary')
+      test.equals(2, cache1.getRequestCounts()['msetItemCount'][0], 'Two of the missed keys should be mset() back to primary')
+      test.equals('value2', cache1.getSync('key2'), 'key2 should be been written back to cache1')
+      test.equals('value4', cache1.getSync('key4'), 'key4 should be been written back to cache1')
+      test.equals(undefined, cache1.getSync('key5'), 'key5 should still be a miss')
+    })
+})
+
+builder.add(function testAvoidDoubleReadForGet(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache1')
+  fakeCache1.connect()
+  fakeCache2.connect()
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(fakeCache1)
+  cacheGroup.addWriteOnlyNode(fakeCache2)
+  cacheGroup.enableReadFromSecondary(10)
+
+  return cacheGroup.get('key')
+    .then(function(value) {
+      test.equals(1, fakeCache1.getRequestCounts()['get'], 'The primary server should be hit only once')
+      test.equals(0, fakeCache2.getRequestCounts()['get'], 'The secondary server should not be hit at all, since it has the same URI')
+      test.deepEqual(undefined, value, 'get() should return undefined')
+    })
+})
+
+
+// If the primary and secondry clusters have overlap and 'readFromSecondary'
+// is enabled, mget() should only try to get the keys that are located in the
+// new server, because the keys located on the old servers will still be missed.
+builder.add(function testAvoidDoubleReadFromMget(test) {
+  var fakeCache1 = new zcache.FakeCache(logger, 'FakeCache1')
+  var fakeCache2 = new zcache.FakeCache(logger, 'FakeCache2')
+  var fakeCache3 = new zcache.FakeCache(logger, 'FakeCache3')
+  var fakeCache4 = new zcache.FakeCache(logger, 'FakeCache4')
+
+  var cluster1 = new zcache.CacheCluster()
+  cluster1.addNode('FakeCache1', fakeCache1, 1, 0)
+  cluster1.addNode('FakeCache2', fakeCache2, 1, 0)
+  cluster1.addNode('FakeCache3', fakeCache3, 1, 0)
+  cluster1.connect()
+
+  var cluster2 = new zcache.CacheCluster()
+  cluster2.addNode('FakeCache1', fakeCache1, 1, 0)
+  cluster2.addNode('FakeCache2', fakeCache2, 1, 0)
+  cluster2.addNode('FakeCache3', fakeCache3, 1, 0)
+  cluster2.addNode('FakeCache4', fakeCache4, 1, 0)
+  cluster2.connect()
+
+  var cacheGroup = new zcache.MultiWriteCacheGroup(cluster1)
+  cacheGroup.addWriteOnlyNode(cluster2)
+  cacheGroup.enableReadFromSecondary(10)
+
+  // Generate 1000 random key/value pairs. They all miss in the
+  // primary cluster, so we will try to get all of them from the
+  // secondary cluster. Only the keys that are relocated to the
+  // forth (new) node in the secondary cluster have values.
+  var keys = []
+  var expected = []
+  for (var i = 0; i < 1000; i++) {
+    var key = 'key' + i
+    var value = 'value' + i
+    keys.push(key)
+    if ('FakeCache4' == cluster2.getUrisByKey(key)) {
+      fakeCache4.setSync(key, value)
+      expected.push(value)
+    } else {
+      expected.push(undefined)
+    }
+  }
+
+  // The first cache servers should only be hit once for each key,
+  // although they also belong to the secondary cluster.
+  // The new server in the secondary cluster should be hit for
+  // about 1/4 of the keys and they should all return cached values.
+  return cacheGroup.mget(keys)
+    .then(function(values) {
+      test.deepEqual(expected, values, 'The mget() results should match the expected')
+      var n1 = fakeCache1.getRequestCounts()['mgetItemCount'][0]
+      var n2 = fakeCache2.getRequestCounts()['mgetItemCount'][0]
+      var n3 = fakeCache3.getRequestCounts()['mgetItemCount'][0]
+      var n4 = fakeCache4.getRequestCounts()['mgetItemCount'][0]
+      test.equals(1000, n1 + n2 + n3, 'The servers in the first cluster should get exactly 1000 gets')
+      test.ok(200 < n4 && n4 < 300, 'The new server in the second cluster should be quried for about 1/4 of the keys')
+    })
+})
+


### PR DESCRIPTION
Hello @nicks, @giannic, @sboora, 

Please review the following commits I made in branch 'xiao-read-from-secondary-server'.

fa731f83059724f4839e4dbd3ec83a7b8a088ec5 (2014-03-20 14:25:10 -0700)
Read missed keys from secondary server
In a following up PR, I will make MultiWriteCacheGroup to have
only two servers, one primary and one seconday. It doesn't seem
to very useful to have multiple write-only servers.

R=@nicks
R=@giannic
R=@sboora
