### PR TITLE
Make InMemoryCache's set(), mset() and del() return promises

### DIFF
--- a/lib/InMemoryCache.js
+++ b/lib/InMemoryCache.js
@@ -123,24 +123,36 @@ InMemoryCache.prototype.mget = function (keys) {
 
 /** @override */
 InMemoryCache.prototype.set = function (key, val, maxAgeMs) {
-  if ((maxAgeMs === undefined || maxAgeMs <= 0) && !this._maxAgeOverride) throw new Error('maxAge must either be positive or overriden with a positive overrideMaxAgeMs')
-
-  this._expireAt[key] = Date.now() + (this._maxAgeOverride || maxAgeMs )
-  return this._data[key] = val
+  if ((maxAgeMs === undefined || maxAgeMs <= 0) && !this._maxAgeOverride) {
+    return Q.reject(new Error('maxAge must either be positive or overriden with a positive overrideMaxAgeMs'))
+  }
+  this._setInternal(key, val, maxAgeMs)
+  return Q.resolve()
 }
 
-/** @override */
-InMemoryCache.prototype.mset = function (items, maxAgeMs) {
-  for (var i = 0; i < items.length; i++) {
-    this.set(items[i].key, items[i].value, maxAgeMs)
+InMemoryCache.prototype.mset = function (items, maxAgeMs, setWhenNotExist) {
+  if ((maxAgeMs === undefined || maxAgeMs <= 0) && !this._maxAgeOverride) {
+    return Q.reject(new Error('maxAgeMs must either be positive or overriden with a positive overrideMaxAgeMs'))
   }
+  for (i = 0; i < items.length; i++) {
+    this._setInternal(items[i].key, items[i].value, maxAgeMs)
+  }
+  return Q.resolve()
+}
+
+/**
+ * A helper function that sets an individual value.
+ */
+InMemoryCache.prototype._setInternal = function (key, val, maxAgeMs) {
+  this._expireAt[key] = Date.now() + (this._maxAgeOverride || maxAgeMs )
+  this._data[key] = val
 }
 
 /** @override */
 InMemoryCache.prototype.del = function (key) {
   ;delete this._data[key]
   ;delete this._expireAt[key]
-  return true
+  return Q.resolve()
 }
 
 /** @override */

--- a/test/test_InMemoryCache.js
+++ b/test/test_InMemoryCache.js
@@ -20,20 +20,41 @@ exports.testInMemoryCache = function (test) {
 }
 
 exports.testCacheSet = function (test) {
+  var self = this
   test.equal(0, this.cI.getKeyCount(), 'There is no key in cache')
   this.cI.set('foo', 'bar', 10000)
-  test.equal(this.cI._data['foo'], 'bar', 'bar should be returned')
-  test.equal(1, this.cI.getKeyCount(), 'There is 1 key in cache')
-  test.done()
+    .then(function() {
+      test.equal(self.cI._data['foo'], 'bar', 'bar should be returned')
+      test.equal(1, self.cI.getKeyCount(), 'There is 1 key in cache')
+      test.done()
+    })
+}
+
+exports.testCacheMset = function (test) {
+  var self = this
+  var items = [
+    {key: 'key1', value: 'value1'},
+    {key: 'key2', value: 'value2'}
+  ]
+
+  test.equal(0, this.cI.getKeyCount(), 'There is no key in cache')
+  this.cI.mset(items, 10000)
+    .then(function() {
+      test.equal('value1', self.cI._data['key1'], '"key1" should be set')
+      test.equal('value2', self.cI._data['key2'], '"key2" should be set')
+      test.equal(2, self.cI.getKeyCount(), 'There should be two keys in cache')
+      test.done()
+    })
 }
 
 exports.testCacheSetImproperMaxAge = function (test) {
-  var client = this
-  test.throws(function () {
-    client.cI.set('foo', 'bar')
-  })
-
-  test.done()
+  this.cI.set('foo', 'bar')
+    .then(function () {
+      test.fail('Invalide max age parameter should fail the test')
+    })
+    .fail(function () {
+      test.done()
+    })
 }
 
 exports.testCacheOverrideMaxAgeMs = function (test) {
@@ -110,25 +131,15 @@ exports.testCacheGetundefined = function (test) {
 }
 
 exports.testCacheDel = function (test) {
-  this.cI.set('foo', 1, 1000)
-  this.cI.del('foo')
-  test.deepEqual(this.cI._data['foo'], undefined, 'foo should have been deleted')
-  test.done()
-}
-
-exports.testCacheMset = function (test) {
-  var sampleKeys = [
-    {key: 'a', value: 1},
-    {key: 'b', value: 2},
-    {key: 'c', value: 3}
-  ]
-
-  this.cI.mset(sampleKeys, 1000)
-  test.equal(this.cI._data['a'], 1, 'a should be 1')
-  test.equal(this.cI._data['b'], 2, 'b should be 2')
-  test.equal(this.cI._data['c'], 3, 'c should be 3')
-  test.equal(3, this.cI.getKeyCount(), 'There are 3 keys in cache')
-  test.done()
+  var self = this
+  self.cI.set('foo', 1, 1000)
+    .then(function () {
+      return self.cI.del('foo')
+    })
+    .then(function () {
+      test.deepEqual(self.cI._data['foo'], undefined, 'foo should have been deleted')
+      test.done()
+    })
 }
 
 exports.testCacheMget = function (test) {


### PR DESCRIPTION
Hello @nicks, @giannic, 

Please review the following commits I made in branch 'xiao-add-promise'.

8e505a92d8980d165b81bd6f3c7570573fe8014a (2014-03-24 09:11:55 -0700)
Make InMemoryCache's set(), mset() and del() return promises
I'm not sure why they don't return promises at the first place. My guess is
for the sake or performance and/or sometimes we don't wait for those functions
to return?

Anyway, we should make them return promises. The performance gained by
creating fewer promises can't justify the problems it will cause, e.g.,
they don't implement the interface defined by CacheInstance, which could be
confusing and bug prone. Plus, people may want to wait for these functions
to return in most cases.

R=@nicks
R=@giannic
