### PR TITLE
A perf optimization on compare uri lists

### DIFF
--- a/lib/CachePair.js
+++ b/lib/CachePair.js
@@ -215,6 +215,9 @@ CachePair.prototype.getPendingRequestsCount = function () {
 CachePair.prototype._maybeOnSecondary = function (key) {
   var urisPrimary = this._primary.getUrisByKey(key)
   var urisSecondary = this._secondary.getUrisByKey(key)
+  if (urisPrimary.length === 1 && urisSecondary.length === 1) {
+    return urisPrimary[0] !== urisSecondary[0]
+  }
   for (var i = 0; i < urisSecondary.length; i++) {
     if (urisPrimary.indexOf(urisSecondary[i]) < 0) return true
   }


### PR DESCRIPTION
Hello @nicks, @giannic, @sugunasubra, 

Please review the following commits I made in branch 'xiao-perf-optimization'.

90bf49e816461c3785aaae369fc43b899ed69ace (2014-03-25 23:03:24 -0700)
A perf optimization on compare uri lists
This optimization is based on this benchmark results:

```
Benchmark                                Samples      Time   GC Time        Per                Rate

  Check length and directly compare    1,000,000    0.004s    0.000s    0.004µs      237,000,000/sec
  Loop through and run indexOf         1,000,000    0.032s    0.000s    0.032µs       31,600,000/sec
```

R=@nicks
R=@giannic
R=@sugunasubra
