### PR TITLE
Do not throw error immediately if some server fails in a cluster

### DIFF
--- a/lib/CacheCluster.js
+++ b/lib/CacheCluster.js
@@ -122,7 +122,6 @@ CacheCluster.prototype.mget = function (keys) {
     promises.push(this._servers[uri].mget(keysOnInstance)
       .then(setValues.bind(null, values, keysOnInstance))
       .fail(setError.bind(null, errors, keysOnInstance))
-      .end()
     )
   }
 
@@ -175,7 +174,6 @@ CacheCluster.prototype.mset = function (items, maxAgeMs) {
       .fail(setError.bind(null, errors, itemsOnInstance.map(function (item) {
         return item.key
       })))
-      .end()
     )
   }
 


### PR DESCRIPTION
Hello @nicks, 

Please review the following commits I made in branch 'xiao-handle-error'.

6074f6759805f0e5de0f3b96dac83528f22622b0 (2014-04-04 08:55:07 -0700)
Do not throw error immediately if some server fails in a cluster
Remove the .end() call chained to per-server promise, so if a server
fails, it won't throw error right away, instead, it will let
Q.allSettled() to aggregate the error.

R=@nicks
