### PR TITLE
"Adding changes to use snappy to compress cache values longer than pivot in cache. Note clients of zcache will still see exact same values, whether data is compressed or not. Behavior is controlled by config."

### DIFF
--- a/externs/snappy.js
+++ b/externs/snappy.js
@@ -1,0 +1,33 @@
+// Copyright 2014. A Medium Corporation.
+
+/**
+ * @param {string} value
+ * @return {Buffer}
+ */
+function compressSync(value) {}
+
+/**
+ * @param {Buffer} value
+ * @param {function(Buffer): string} parser
+ * @return {string}
+ */
+function decompressSync(value, parser) {}
+
+/**
+ * @param {Buffer} value
+ * @return {string}
+ */
+function parse(value) {}
+
+var parsers = {
+  json: parse,
+  string: parse,
+  raw: parse
+}
+
+module.exports = {
+  parsers: parsers,
+  compressSync: compressSync,
+  decompressSync: decompressSync
+}
+

--- a/lib/RedisConnection.js
+++ b/lib/RedisConnection.js
@@ -1,6 +1,7 @@
 var redis = require('redis')
 var util = require('util')
 var Q = require('kew')
+var snappy = require('snappy')
 
 var CacheInstance = require('./CacheInstance')
 var ServerInfo = require('./ServerInfo')
@@ -12,7 +13,7 @@ var TimeoutError = require('./TimeoutError')
  * @constructor
  * @param {string} host The host that runs the redis-server
  * @param {number} port The port that the redis-server listens to
- * @param {{requestTimeoutMs: (number|undefined)}=} options Additional options for this connection.
+ * @param {{requestTimeoutMs: (number|undefined), compressionEnabled: (boolean|undefined)}=} options Additional options for this connection.
  *     'requestTimeoutMs' specifies the timeout of a Redis request.
  * @extends CacheInstance
  */
@@ -27,6 +28,15 @@ function RedisConnection(host, port, options) {
   this._bound_onConnect = this._onConnect.bind(this)
   this._bound_onError = this._onError.bind(this)
   this._bound_onEnd = this._onEnd.bind(this)
+  
+  // Controls if we turn on compression or not. 
+  // All cache values which are longer than the pivot are eligible for compression
+  // Pivot and encoding prefix are hardcoded for now. Will revisit after
+  // we know we are using snappy for sure
+  this._snappyPivot = 750
+  this._compressedPrefix = '@snappy@'
+  this._uncompressedPrefix = '@orig@'
+  this._compressionEnabled = (options && options.compressionEnabled) || false
 }
 util.inherits(RedisConnection, CacheInstance)
 
@@ -38,7 +48,7 @@ RedisConnection.prototype.isAvailable = function () {
 /** @override */
 RedisConnection.prototype.set = function (key, val, maxAgeMs, setWhenNotExist) {
   var deferred = Q.defer()
-  var params = [key, val, 'PX', maxAgeMs]
+  var params = [key, this._compress(val), 'PX', maxAgeMs]
   if (setWhenNotExist) params.push('NX')
   this._client.set(params, this._makeNodeResolverWithTimeout(deferred, 'set', 'Redis [set] key: ' + key))
   return deferred.promise
@@ -54,7 +64,7 @@ RedisConnection.prototype.mset = function (items, maxAgeMs, setWhenNotExist) {
   if (setWhenNotExist) {
     // Use "SET" to set each key with a "NX" flag.
     for (i = 0, l = items.length; i < l; i++) {
-      commands.push(['set', items[i].key, items[i].value, 'PX', maxAgeMs, 'NX'])
+      commands.push(['set', items[i].key, this._compress(items[i].value), 'PX', maxAgeMs, 'NX'])
     }
   } else {
     // Use "MSET" to set all the keys and "EXPIRE" to set TTL for each key
@@ -63,7 +73,7 @@ RedisConnection.prototype.mset = function (items, maxAgeMs, setWhenNotExist) {
     for (i = 0, l = items.length; i < l; i++) {
       var key = items[i].key
       // Append key value arguments to the set command.
-      msetCommand.push(key, items[i].value)
+      msetCommand.push(key, this._compress(items[i].value))
       // Append an expire command.
       commands.push(['EXPIRE', key, Math.floor(maxAgeMs / 1000)])
     }
@@ -92,7 +102,7 @@ RedisConnection.prototype.get = function (key) {
 /** @override */
 RedisConnection.prototype.mget = function (keys) {
   if (!keys || !keys.length) return Q.resolve([])
-
+  var self = this
   var deferred = Q.defer()
   this._client.mget(keys,
       this._makeNodeResolverWithTimeout(deferred, 'mget',
@@ -105,7 +115,12 @@ RedisConnection.prototype.mget = function (keys) {
       // Redis client returns null objects for cache misses, and we
       // turn them into undefined.
       for (var i = 0; i < vals.length; i++) {
-        if (null === vals[i]) vals[i] = undefined
+        if (null === vals[i]) {
+          vals[i] = undefined
+        } else {
+          //for real values determine if you need to decompress
+          vals[i] = self._decompress(vals[i])
+        }
       }
       return vals
     })
@@ -236,6 +251,57 @@ RedisConnection.prototype._makeNodeResolverWithTimeout = function (deferred, opN
     }
     // TODO(Xiao): even if it's timeout, we may want to log the error message
     // if this request finally goes through but fails.
+  }
+}
+
+/**
+ * Private method controls how all cache values are encoded.
+ *
+ * @param {string|undefined|null} value Original cache value
+ * @return {string|undefined|null} Value encoded appropriately for the cache
+ */
+RedisConnection.prototype._compress = function (value) {
+  if (!value || !this._compressionEnabled) {
+    return value
+  }
+
+  if (value.length > this._snappyPivot) {
+    try {
+      var compressed = snappy.compressSync(value)
+      return this._compressedPrefix + compressed.toString('base64')
+    } catch (e) {
+      console.warn("Compression failed: " + e.message)
+      return this._uncompressedPrefix + value 
+    }
+  } else {
+    return this._uncompressedPrefix + value
+  }
+}
+
+/**
+ * Private Method that knows how to parsed encoded cache value and decode.
+ *
+ * @param {string|undefined|null} value Possibly encoded value retrieved from the cache.
+ * @return {string|undefined|null} The original input value
+ */
+RedisConnection.prototype._decompress = function (value) {
+  if (!value) return value
+
+  // Note: always check prefixes even if compression is disabled, as there might
+  // be entries from prior to disabling compression
+  if (value.indexOf(this._compressedPrefix) === 0) {
+    try {
+      var compressedBuf = new Buffer(value.substring(this._compressedPrefix.length), 'base64')
+      var orig = snappy.decompressSync(compressedBuf, snappy.parsers.string)
+      return orig
+    } catch (e) {
+      console.warn("Decompression failed: " + e.message)
+      return undefined 
+    }  
+  } else if (value.indexOf(this._uncompressedPrefix) === 0) {
+    return value.substring(this._uncompressedPrefix.length)
+  } else {
+    return value
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zcache",
   "description": "AWS zone-aware multi-layer cache",
-  "version": "0.4.0-alpha",
+  "version": "0.4.0-beta",
   "homepage": "https://github.com/Medium/zcache",
   "authors": [
     "Jeremy Stanley <github@azulus.com> (https://github.com/azulus)",
@@ -21,7 +21,8 @@
     "redis": "0.8.2",
     "hiredis": "0.1.16",
     "metrics": "0.1.6",
-    "hashring": "1.0.3"
+    "hashring": "1.0.3",
+    "snappy": "2.1.2"
   },
   "devDependencies": {
     "nodeunit": "0.7.4",
@@ -36,7 +37,8 @@
     "hashring": "./externs/hashring.js",
     "node-memcache-parser-obvfork": "./externs/node-memcache-parser-obvfork.js",
     "generic-pool": "./externs/generic-pool.js",
-    "metrics": "./externs/metrics.js"
+    "metrics": "./externs/metrics.js",
+    "snappy": "./externs/snappy.js"
   },
   "scripts": {
     "test": "./node_modules/.bin/closure-npc --jscomp_error=checkTypes && ./node_modules/nodeunit/bin/nodeunit test"


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'suguna-snappy'.

faa73cc9a0f8f5b5c11ecc1e65fb1a5645e0f93e (2014-04-04 10:44:55 -0700)
Refactoring some common code.

R=@x-ma
