### PR TITLE
Add a test cases for how MultiplexingCache handles errors

### DIFF
--- a/test/test_MultiplexingCache.js
+++ b/test/test_MultiplexingCache.js
@@ -158,3 +158,24 @@ builder.add(function testConcurrentMGetsWithMSet(test) {
     test.deepEqual(results[1], ['1', '20', '30', '4'])
   })
 })
+
+
+builder.add(function testConcurrentMGetsWithExceptions(test) {
+  fake.setSync('a', '1')
+  fake.setSync('b', '2')
+  fake.setSync('c', '3')
+  fake.setSync('d', '4')
+  fake.setSync('e', '5')
+  fake.setSync('f', '6')
+  fake.setSync('g', '7')
+
+  fake.setFailureCount(1)
+  var p1 = cache.mget(['a', 'b', 'c'])
+  var p2 = cache.mget(['b', 'c', 'd'])
+  var p3 = cache.mget(['e', 'f', 'g'])
+  return Q.all([p1, p2, p3]).then(function (results) {
+    test.deepEqual(results[0], [undefined, undefined, undefined])
+    test.deepEqual(results[1], [undefined, undefined, '4'])
+    test.deepEqual(results[2], ['5', '6', '7'])
+  })
+})


### PR DESCRIPTION
Hello @dpup, 

Please review the following commits I made in branch 'xiao-add-test-cases'.

d0c509f9d5335364ea942739910e21b4b0f15278 (2014-05-28 12:12:29 -0700)

```
Add a test cases for how MultiplexingCache handles errors

Currently MultiplexingCache swallows errors, which I don't think it should
do. I will think of a way to handle errors. This commit just add an explicit
test case to reveal the current behavior.
```

R=@dpup
