### PR TITLE
Make RedundantCacheGroup properly handles partial failures

### DIFF
--- a/lib/RedundantCacheGroup.js
+++ b/lib/RedundantCacheGroup.js
@@ -3,6 +3,7 @@ var Q = require('kew')
 
 var CacheInstance = require('./CacheInstance')
 var cacheUtils = require('./CacheUtils')
+var PartialResultError = require('./PartialResultError')
 
 /**
  * @constructor
@@ -82,6 +83,11 @@ RedundantCacheGroup.prototype.destroy = function () {
 }
 
 /**
+ * Fetch multiple keys from the highest level cache to the lowest. For missed keys,
+ * fetch them from the next level cache; if it runs into errors, stop and throw
+ * a PartialResultError that includes the hit keys so far.
+ *
+ * @param {Array.<string>} keys
  * @param {number=} start
  * @override
  */
@@ -94,25 +100,53 @@ RedundantCacheGroup.prototype.mget = function (keys, start) {
   return this._getAvailableInstance(instanceIndex).mget(keys)
     .then(function (res) {
       var nextInstanceIndex = self._getIndexOfFirstAvailableInstance(instanceIndex + 1)
-      var promises = []
+      var missedKeys = []
+      var missedKeyIndex = []
 
       for (var i = 0; i < keys.length; i++) {
-        if (!res[i] && nextInstanceIndex != null) {
-          var rollUp = []
-          var startOfHole = i
-          while (i < keys.length && !res[i]) rollUp.push(keys[i++])
-
-          promises.push(self.mget(rollUp, nextInstanceIndex)
-            .then(function (itemIndex, data) {
-              if (data === undefined) return undefined
-              for (var k = 0; k < data.length; k++) res[itemIndex + k] = data[k]
-            }.bind(null, startOfHole)))
+        if (typeof res[i] === 'undefined') {
+          missedKeys.push(keys[i])
+          missedKeyIndex.push(i)
         }
       }
 
-      return Q.all(promises).then(function () {
+      if (missedKeys.length === 0 || !nextInstanceIndex) {
         return res
-      })
+      }
+
+      return self.mget(missedKeys, nextInstanceIndex)
+        .then(function (resFromNextLevel) {
+          for (var i = 0; i < missedKeys.length; i++) {
+            res[missedKeyIndex[i]] = resFromNextLevel[i]
+          }
+          return res
+        })
+        .fail(function (errFromNextLevel) {
+          // If there are no partial results from the current level, no need to
+          // merge results.
+          if (keys.length === missedKeys.length) {
+            throw errFromNextLevel
+          }
+
+          if (errFromNextLevel instanceof PartialResultError) {
+            var data = errFromNextLevel.getData()
+            for (var i = 0; i < keys.length; i++) {
+              if (typeof res[i] !== 'undefined') data[keys[i]] = res[i]
+            }
+            throw new PartialResultError(data, errFromNextLevel.getError())
+          } else {
+            var data = {}
+            var err = {}
+            for (var i = 0; i < keys.length; i++) {
+              if (typeof res[i] !== 'undefined') {
+                data[keys[i]] = res[i]
+              } else {
+                err[keys[i]] = errFromNextLevel
+              }
+            }
+            throw new PartialResultError(data, err)
+          }
+        })
     })
 }
 


### PR DESCRIPTION
Hello @eford1, @chaosgame, @nicks, 

Please review the following commits I made in branch 'xiao-let-RedundantCacheGroup-handle-partial-failure'.

e350ba808399bd6d0f01416b99951918718da4e3 (2014-09-29 14:00:13 -0700)

```
Make RedundantCacheGroup properly handles partial failures

If it gets a partial failure, it will properly propogate existing results
and throw another partial failure.

It stops at the first time when an error happens and propogate that error
to upstream, in other words, it will fetch failed keys even if there are
other layers to try.
```

R=@eford1
R=@chaosgame
R=@nicks
