### PR TITLE
flatten partial result errors properly

### DIFF
--- a/lib/PartialResultError.js
+++ b/lib/PartialResultError.js
@@ -54,7 +54,11 @@ PartialResultError.prototype._flattenData = function (data, errors) {
       }
       var partialResultDataObject = errors[errorKey].getData()
       for (var dataKey in partialResultDataObject) {
-        data[dataKey] = partialResultDataObject[dataKey]["value"]
+        if (partialResultDataObject[dataKey]) {
+          // the value may already be unpacked; we should be able to handle both "keyName": "val" as 
+          // well as "keyName": {"value": "val"}
+          data[dataKey] = partialResultDataObject[dataKey]["value"] ? partialResultDataObject[dataKey]["value"] : partialResultDataObject[dataKey]
+        }
       }
     } else {
       flattenedErrors[errorKey] = errors[errorKey]


### PR DESCRIPTION
Hello @x-ma, 

Please review the following commits I made in branch 'eford-fix-read-undefined-in-partial-results'.

1a8504cf904f6c2e94b6b60716e62b9d8f0a062d (2014-10-16 16:57:54 -0700)
flatten partial result errors properly

R=@x-ma
VISIBLE_CHANGES=flatten partial result errors properly
